### PR TITLE
Fixes issue with spaces in filesystem name.

### DIFF
--- a/libs/disk.php
+++ b/libs/disk.php
@@ -5,7 +5,7 @@ $Config = new Config();
 
 $datas = array();
 
-if (!(exec('/bin/df -T | tail -n +2 | awk \'{print $2","$3","$4","$5","$6","$7}\'', $df)))
+if (!(exec('/bin/df -T | awk -v c=`/bin/df -T | grep -bo "Type" | awk -F: \'{print $1}\'` \'{print substr($0,c);}\' | tail -n +2 | awk \'{print $1","$2","$3","$4","$5","$6}\'', $df)))
 {
     $datas[] = array(
         'total'         => 'N.A',


### PR DESCRIPTION
In some cases a filesystem name returned by `/bin/df` can contain a space, which causes the original command to mix up the columns:

```
Filesystem                 Type     1K-blocks     Used Available Use% Mounted on
rootfs                     rootfs     7430700  3073596   4009880  44% /
//192.168.1.254/Disque dur cifs     239216096 80122196 146919316  36% /mnt/Freebox

```

In that case we can't rely on awk to separate columns with the space character. In this commit I basically removed the whole filesystem column since it is not used.
