### PR TITLE
Fix memory and swap

### DIFF
--- a/libs/cpu.php
+++ b/libs/cpu.php
@@ -46,6 +46,7 @@ else
                 break;
 
                 case 'bogomips':
+                case 'BogoMIPS':
                     $bogomips = $value;
                 break;
             }

--- a/libs/memory.php
+++ b/libs/memory.php
@@ -2,22 +2,32 @@
 require 'Utils/Misc.class.php';
 
 // Free
-if (!($free = shell_exec('/usr/bin/free -to | grep Mem: | awk \'{print $4+$6+$7}\'')))
+if (!($free = shell_exec('/usr/bin/free | grep Mem: | awk \'{print $7}\'')))
 {
     $free = 0;
 }
 
 // Total
-if (!($total = shell_exec('/usr/bin/free -to | grep Mem: | awk \'{print $2}\'')))
+if (!($total = shell_exec('/usr/bin/free | grep Mem: | awk \'{print $2}\'')))
 {
     $total = 0;
 }
 
 // Used
-$used = $total - $free;
+if (!($used = shell_exec('/usr/bin/free | grep Mem: | awk \'{print $3}\'')))
+{
+    $used = 0;
+}
 
 // Percent used
-$percent_used = 100 - (round($free / $total * 100));
+if ($total == 0)
+{
+    $percent_used = 0;
+}
+else
+{
+    $percent_used = 100 - (round($free / $total * 100));
+}
 
 
 $datas = array(

--- a/libs/swap.php
+++ b/libs/swap.php
@@ -2,23 +2,32 @@
 require 'Utils/Misc.class.php';
 
 // Free
-if (!($free = shell_exec('grep SwapFree /proc/meminfo | awk \'{print $2}\'')))
+if (!($free = shell_exec('/usr/bin/free -t | sed -n \'3p\' | awk \'{print $5}\'')))
 {
     $free = 0;
 }
 
 // Total
-if (!($total = shell_exec('grep SwapTotal /proc/meminfo | awk \'{print $2}\'')))
+if (!($total = shell_exec('/usr/bin/free -t | sed -n \'3p\' | awk \'{print $3}\'')))
 {
     $total = 0;
 }
 
 // Used
-$used = $total - $free;
+if (!($used = shell_exec('/usr/bin/free -t | sed -n \'3p\' | awk \'{print $4}\'')))
+{
+    $used = 0;
+}
 
 // Percent used
-$percent_used = 100 - (round($free / $total * 100));
-
+if ($total == 0)
+{
+    $percent_used = 0;
+}
+else
+{
+    $percent_used = 100 - (round($free / $total * 100));
+}
 
 $datas = array(
     'used'          => Misc::getSize($used * 1024),


### PR DESCRIPTION
For the memory, I remove the option « -to » which doesn't exist, and I simplified the retrieving of the memory info.  
For the swap, I used « free -t » to retrieve the swap info.  
For teh CPU, I added « BogoMIPS » in addition to « bogomips ».