### PR TITLE
Disable Panels in config-file

### DIFF
--- a/conf/esm.config.json
+++ b/conf/esm.config.json
@@ -11,7 +11,6 @@
         "enable_temperature": true
     },
     "disk": {
-        "enable": true,
         "show_tmpfs": false,
         "show_filesystem": true
     },

--- a/conf/esm.config.json
+++ b/conf/esm.config.json
@@ -11,10 +11,12 @@
         "enable_temperature": true
     },
     "disk": {
+        "enable": true,
         "show_tmpfs": false,
         "show_filesystem": true
     },
     "ping": {
+        "enable": true,
         "hosts": [
             "facebook.com",
             "google.com",
@@ -26,6 +28,7 @@
         "max": 5
     },
     "services": {
+        "enable": true,
         "show_port": true,
         "list": [
             {

--- a/index.php
+++ b/index.php
@@ -315,6 +315,7 @@ $update = $Config->checkUpdate();
     <div class="cls"></div>
 
 
+    <?php if ($Config->get('last_login:enable') == true): ?>
     <div class="t-center">
         <div class="box column-left column-33" id="esm-last_login">
             <div class="box-header">
@@ -325,18 +326,15 @@ $update = $Config->checkUpdate();
             </div>
 
             <div class="box-content">
-                <?php if ($Config->get('last_login:enable') == true): ?>
                     <table>
                         <tbody></tbody>
                     </table>
-                <?php else: ?>
-                    <p>Disabled</p>
-                <?php endif; ?>
             </div>
         </div>
+    <?php endif; ?>
 
 
-
+    <?php if ($Config->get('services:enable') == true): ?>
         <div class="box column-right column-33" id="esm-services">
             <div class="box-header">
                 <h1>Services status</h1>
@@ -351,10 +349,11 @@ $update = $Config->checkUpdate();
                 </table>
             </div>
         </div>
+    <?php endif; ?>
 
 
 
-
+     <?php if ($Config->get('ping:enable') == true): ?>
         <div class="box t-center" style="margin: 0 33%;" id="esm-ping">
             <div class="box-header">
                 <h1>Ping</h1>
@@ -369,6 +368,7 @@ $update = $Config->checkUpdate();
                 </table>
             </div>
         </div>
+    <?php endif; ?>
 
     </div>
 


### PR DESCRIPTION
Hello!

I ended up not using the bottom row of panels (Last Login, Ping, Services), but even if they are empty, these panels are still there. To remove clutter, I added the possibility to completely remove these panels by setting the corresponding flag in the config file to false.

I'm happy about any feedback.