### PR TITLE
Adds option to ignore mounts via config file

### DIFF
--- a/conf/esm.config.json
+++ b/conf/esm.config.json
@@ -12,7 +12,8 @@
     },
     "disk": {
         "show_tmpfs": false,
-        "show_filesystem": true
+        "show_filesystem": true,
+        "ignore_mounts": []
     },
     "ping": {
         "hosts": [

--- a/libs/disk.php
+++ b/libs/disk.php
@@ -32,6 +32,12 @@ else
         if (strpos($type, 'tmpfs') !== false && $Config->get('disk:show_tmpfs') === false)
             continue;
 
+        foreach ($Config->get('disk:ignore_mounts') as $to_ignore)
+        {
+            if ($mount === $to_ignore)
+                continue 2;
+        }
+
         if (!in_array($mount, $mounted_points))
         {
             $mounted_points[] = trim($mount);


### PR DESCRIPTION
Hello!

This allows to configure eZ Server Monitor to ignore certain disks via the `"ignore_mounts" `option in the configuration file. You can either create no `"ignore_mounts"` option at all, or set it to `[]` if you want to
show all mounts.

To ignore certain mounts, add the exact mount path to the array, e.g. `["/mnt/disk1"]` or `["/mnt/disk1", "/mnt/disk2"]`. This is done with *exact* string matching, so make sure the entries are correct. This makes it possible to ignore `"/"` and still show other paths.