### PR TITLE
fix command df -T for long name mounted disks

### DIFF
--- a/libs/disk.php
+++ b/libs/disk.php
@@ -6,7 +6,7 @@ $datas = array();
 
 # if there are more than 7 awk's colums it means the mount point name contains spaces
 # so consider the first colums as a unique colum and the last 6 as real colums
-if (!(exec('/bin/df -T -P | tail -n +2 | awk \'{ if (NF > 7) { for (i=1; i<NF-6; i++) { printf("%s ", $i); } for (i=NF-6; i<NF; i++) { printf("%s,", $i); } print $NF; } else { print $1","$2","$3","$4","$5","$6","$7; } }\'', $df)))
+if (!(exec('/bin/df -T -P | tail -n +2 | awk \'{ if (NF > 7) { for (i=1; i<NF-6; i++) { printf("%s ", $i); } for (i=NF-6; i<NF; i++) { printf("%s,", $i); } print $NF; } else { print $1","$2","$3","$4","$5","$6","$7; } }\' | sed \':a;N;$!ba;s/,,,,,\n/+/g\' ', $df)))
 {
     $datas[] = array(
         'total'         => 'N.A',


### PR DESCRIPTION
the long name mounted disks are not displayed in the Disk Usage section