### PR TITLE
Added a panel to show the status of the apt packages

### DIFF
--- a/conf/esm.config.json
+++ b/conf/esm.config.json
@@ -67,5 +67,8 @@
                 "protocol": "tcp"
             }
         ]
-    }
+    },
+    "package_management": {
+        "apt": false
+     }
 }

--- a/index.php
+++ b/index.php
@@ -374,7 +374,22 @@ $update = $Config->checkUpdate();
 
     </div>
 
-    
+    <?php if ($Config->get('package_management:apt') == true): ?>
+    <div class="box column-left column-33" id="esm-apt">
+        <div class="box-header">
+            <h1>Package Update Status</h1>
+            <ul>
+                <li><a href="#" class="reload" onclick="esm.reloadBlock('apt');"><span class="icon-cycle"></span></a></li>
+            </ul>
+        </div>
+
+        <div class="box-content">
+            <table>
+                <tbody></tbody>
+            </table>
+        </div>
+    </div>
+    <?php endif; ?>
 
     <div class="cls"></div>
 

--- a/js/esm.js
+++ b/js/esm.js
@@ -294,6 +294,42 @@ esm.getServices = function() {
 
 }
 
+esm.getAptStatus = function() {
+    var module = 'apt';
+
+    esm.reloadBlock_spin(module);
+
+    $.get('libs/'+module+'.php', function(data) {
+        var $box = $('.box#esm-'+module+' .box-content tbody');
+        $box.empty();
+
+	var html = '';
+
+        if( data.status === 0 ) {
+            var package_color = data.standard > 0 ? 'label success' : '';
+            var security_color = data.security > 0 ? 'label error' : '';
+
+            html += '<tr>';
+            html += '<td>Available Package Updates</td>';
+            html += '<td class="w5p"><span class="'+package_color+'">'+data.standard+'</span></td>';
+            html += '</tr>';
+            html += '<tr>';
+            html += '<td>Available Security Updates</td>';
+            html += '<td class="w5p"><span class="'+security_color+'">'+data.security+'</span></td>';
+            html += '</tr>';
+        } else {
+            // If the module isn't disabled, something else went wrong
+            if( data.status !== 1 ) {
+                console.error("Unable to retrieve package updates", data);
+            }
+	}
+
+	$box.append(html);
+
+        esm.reloadBlock_spin(module);
+    }, 'json');
+}
+
 
 esm.getAll = function() {
     esm.getSystem();
@@ -306,6 +342,7 @@ esm.getAll = function() {
     esm.getNetwork();
     esm.getPing();
     esm.getServices();
+    esm.getAptStatus();
 }
 
 esm.reloadBlock = function(block) {
@@ -367,5 +404,6 @@ esm.mapping = {
     last_login: esm.getLast_login,
     network: esm.getNetwork,
     ping: esm.getPing,
-    services: esm.getServices
+    services: esm.getServices,
+    apt: esm.getAptStatus
 };

--- a/libs/apt.php
+++ b/libs/apt.php
@@ -1,0 +1,73 @@
+<?php
+require '../autoload.php';
+$Config = new Config();
+
+/*
+    Apt package status - This lib checks the status of the packages installed on the system and
+    returns the number of packages that can be upgraded and how many are security updates.
+
+    This lib is specific to Linux distributions that use the APT Package Management System such as
+    Debian and Ubuntu.
+
+    'apt-check' notes:
+    * apt-check is the utility used by apt to determine if there are packages available.
+    * If called with no parameters, it returns with a tuple of numbers in the format: <standard>;<security>
+        - 'standard' is an int representing the upgrade packages available
+        - 'security' is an int representing the security upgrade packages available
+    * At least on Ubuntu 20.x, the path of the 'apt-check' utility is
+        '/usr/lib/update-notifier/apt-check'. The utility and it's path will need to be validated
+        on other Linux distributions and Ubuntu versions.
+
+    Configuration / Usage
+    * The property 'blahblah' must be in the 'esm.config.json' file with the property of 'true'
+        for this library to execute correctly.
+    * Status Values & Messages:
+        - '0' - 'Success' will be set if everything was successful.
+        - '1' - 'Disabled' will be set if this library is disabled.
+        - '2' - 'Failure' will be set if apt-check failed to execute. Can have additional
+            information appended to the message.
+        - '3' - 'Not Available' will be set if apt-check could not be located.
+        - '-1' - 'Unknown' or other messages will be set for any other reason.
+
+*/
+$configKey = 'package_management:apt';
+
+$command_path = '/usr/lib/update-notifier/apt-check';
+
+// apt-check outputs to stderr, 2>&1 concat's stderr to stdout
+$options = '2>&1';
+
+$datas = array();
+
+if (count($Config->get($configKey)) != 1) {
+    $datas['status'] = -1;
+    $datas['message'] = 'Not Configured';
+} elseif ($Config->get($configKey) == false ) {
+    $datas['status'] = 1;
+    $datas['message'] = 'Disabled';
+} elseif ($Config->get($configKey) == true ) {
+    // If the command is configured & enabled
+    if( file_exists($command_path) ) {
+        $command = $command_path . " " . $options;
+        $execresult = exec($command, $output, $retval);
+        if( $execresult ) {
+            $items = explode(';', $output[0]);
+            $datas['status'] = 0;
+            $datas['message'] = 'Success';
+            $datas['standard'] = $items[0];
+            $datas['security'] = $items[1];
+        } else {
+            $datas['status'] = 2;
+            $datas['message'] = 'Failure ' . $retval;
+        }
+    } else {
+        $datas['status'] = 3;
+        $datas['message'] = 'Not Available';
+    }
+} else {
+    // Not sure what's going on here....
+    $datas['status'] = -1;
+    $datas['message'] = 'Unknown';
+}
+
+echo json_encode($datas);


### PR DESCRIPTION
This allows a user to include a status panel of what package updates are pending on an Apt Package managed system such as Ubuntu.

Also included is the configuration file change to include a 'package_management' section that must be configured for proper operation. (I was unable to get the panel to not display if the section was missing) It is currently configured to be not enabled. Change the flag to 'true' to enable the panel.

While setup for Apt, this could easily be extended for yum, pacman, etc and I hope they would include their configuration inside of 'package_management' as well.

Tested on: Ubuntu 20.04.2 LTS (GNU/Linux 5.4.0-72-generic x86_64)